### PR TITLE
chore: removed run_id from run initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .neptune
 
 # Data files
-/how-to-guides/hpo/**/mnist
+**ubyte**

--- a/how-to-guides/hpo/notebooks/Neptune_HPO.ipynb
+++ b/how-to-guides/hpo/notebooks/Neptune_HPO.ipynb
@@ -15,7 +15,7 @@
     "<a target=\"_blank\" href=\"https://scale.neptune.ai/o/examples/org/hpo/runs/table?viewId=9d44261f-32a1-42e7-96ff-9b35edc4be66\">\n",
     "  <img alt=\"Explore in Neptune\" src=\"https://neptune.ai/wp-content/uploads/2024/01/neptune-badge.svg\">\n",
     "</a>\n",
-    "<a target=\"_blank\" href=\"https://docs-beta.neptune.ai/tutorials/hpo/\">\n",
+    "<a target=\"_blank\" href=\"https://docs.neptune.ai/hpo_tutorial\">\n",
     "  <img alt=\"View tutorial in docs\" src=\"https://neptune.ai/wp-content/uploads/2024/01/docs-badge-2.svg\">\n",
     "</a>"
    ]
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,11 +128,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "learning_rates = [0.025, 0.05, 0.075]  # learning rate choices"
+    "learning_rates = [0.025, 0.05, 0.075]"
    ]
   },
   {
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,13 +250,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from uuid import uuid4\n",
+    "run = Run()\n",
     "\n",
-    "run = Run(run_id=f\"hpo-{uuid4()}\")\n",
+    "print(f\"Neptune run created 🎉\\nAccess at {run.get_run_url()}\")\n",
     "\n",
     "run.add_tags([\"all-trials\", \"notebook\"])"
    ]
@@ -401,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,11 +438,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sweep_run = Run(run_id=f\"sweep-{sweep_id}\")\n",
+    "sweep_run = Run()\n",
+    "\n",
+    "print(f\"Neptune sweep-level run created 🎉\\nAccess at {sweep_run.get_run_url()}\")\n",
     "\n",
     "sweep_run.add_tags([\"sweep\", \"notebook\"])"
    ]
@@ -456,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +508,9 @@
     "    desc=\"Trials\",\n",
     "):\n",
     "    # Create a trial-level run\n",
-    "    with Run(run_id=f\"trial-{sweep_id}-{trial}\") as trial_run:\n",
+    "    with Run() as trial_run:\n",
+    "        print(f\"Neptune run created for trial {trial} 🎉\\nAccess at {trial_run.get_run_url()}\")\n",
+    "\n",
     "        trial_run.add_tags([\"trial\", \"notebook\"])\n",
     "\n",
     "        # Add sweep_id to the trial-level run\n",
@@ -597,7 +601,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py310",
+   "display_name": "py311",
    "language": "python",
    "name": "python3"
   },
@@ -611,7 +615,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/how-to-guides/hpo/scripts/neptune_hpo_separate_runs.py
+++ b/how-to-guides/hpo/scripts/neptune_hpo_separate_runs.py
@@ -74,7 +74,8 @@ trainloader = torch.utils.data.DataLoader(
 if __name__ == "__main__":
     sweep_id = str(uuid4())
 
-    sweep_run = Run(run_id=f"sweep-{sweep_id}")
+    sweep_run = Run()
+    print(f"Neptune sweep-level run created 🎉\nAccess at {sweep_run.get_run_url()}")
 
     sweep_run.add_tags(["sweep", "script"])
     sweep_run.add_tags([sweep_id], group_tags=True)
@@ -94,7 +95,9 @@ if __name__ == "__main__":
         desc="Trials",
     ):
         # Create a trial-level run
-        with Run(run_id=f"trial-{sweep_id}-{trial}") as trial_run:
+        with Run() as trial_run:
+            print(f"Neptune run created for trial {trial} 🎉\nAccess at {trial_run.get_run_url()}")
+
             trial_run.add_tags(["trial", "script"])
 
             # Add sweep_id to the trial-level run

--- a/how-to-guides/hpo/scripts/neptune_hpo_single_run.py
+++ b/how-to-guides/hpo/scripts/neptune_hpo_single_run.py
@@ -1,6 +1,5 @@
 import math
 from datetime import datetime
-from uuid import uuid4
 
 import torch
 import torch.nn as nn
@@ -72,7 +71,8 @@ trainloader = torch.utils.data.DataLoader(
 )
 
 if __name__ == "__main__":
-    run = Run(run_id=f"hpo-{uuid4()}")
+    run = Run()
+    print(f"Neptune run created 🎉\nAccess at {run.get_run_url()}")
 
     run.add_tags(["all-trials", "script"])
 


### PR DESCRIPTION
# Description

* Removed explicit `run_id` from run initialization where not needed
* Added run URL after initialization

__Related to:__ https://app.clickup.com/t/8698d6yq0

__Any expected test failures?__
* Tests on MacOS 13 with Py3.13 will fail due to no torch distribution available yet
* Tests on Windows with Py3.13 will fail due to numpy incompatibilities

---

Add a `[X]` to relevant checklist items

## ❔ This change

- [X] adds a new feature
- [ ] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [ ] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows
- Python version: 3.11.9
- Neptune version: 0.11.3
- Affected libraries with version:
