### PR TITLE
2.x to 3.x migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo contains tutorials and examples of how to use Neptune.
 |                                         | Docs                         | GitHub                            |
 | --------------------------------------- | -----------------------------| --------------------------------- |
 | Import runs from Weights & Biases       | [![docs-icon]][from-wandb]   | [![github-icon]][from-wandb-code] |
-| Migrate code from Neptune Legacy client | [![docs-icon]][from-legacy]  |                                   |
+| Migrate code from Neptune Legacy client | [![docs-icon]][from-legacy]  | [![github-icon]][from-legacy-code] |
 
 ## Can't find what you're looking for?
 
@@ -38,6 +38,7 @@ This repo contains tutorials and examples of how to use Neptune.
 
 <!-- Internal -->
 [from-wandb-code]: utils/migration_tools/from_wandb/
+[from-legacy-code]: utils/migration_tools/from_legacy_neptune/
 [hpo-notebook]: how-to-guides/hpo/notebooks/Neptune_HPO.ipynb
 [hpo-colab]: https://colab.research.google.com/github/neptune-ai/scale-examples/blob/master/how-to-guides/hpo/notebooks/Neptune_HPO.ipynb
 [qs-notebook]: how-to-guides/quickstart/notebooks/neptune_quickstart.ipynb

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -1,0 +1,151 @@
+# Copying runs from Neptune Legacy (2.x) to Neptune (3.x)
+
+This script helps you copy runs from Neptune Legacy (2.x) to Neptune (3.x).
+
+---
+## Changelog
+- 2025-05-16 - Initial release
+
+## Quick Start
+
+Install the required packages:
+```bash
+pip install -U neptune-scale neptune
+```
+
+Run the migration script:
+```bash
+python runs_migrator.py \
+  --legacy-token <NEPTUNE_2.X_API_TOKEN> \
+  --new-token <NEPTUNE_3.X_API_TOKEN> \
+  --new-workspace <NEPTUNE_3.X_WORKSPACE_NAME> \
+  --legacy-project <LEGACY_WORKSPACE/PROJECT_NAME> \
+```
+
+---
+
+## Arguments
+
+- `--legacy-token` (required): API token for the legacy Neptune workspace (2.x).
+- `--new-token` (required): API token for the new Neptune workspace (3.x).
+- `--new-workspace` (required): Name of the new workspace in Neptune 3.x.
+- `--legacy-project` (required): Name of the legacy project in the format `WORKSPACE_NAME/PROJECT_NAME`.
+- `--query` (optional): Query filter for runs to be copied ([NQL syntax](https://docs-legacy.neptune.ai/usage/nql/)).
+- `--max-workers` (optional): Maximum number of parallel workers to use for copying runs. Defaults to using ThreadPoolExecutor's default.
+
+---
+
+## Prerequisites
+- A Neptune 2.x workspace with runs to migrate.
+- A Neptune 3.x workspace with write access to migrate the runs to.
+- Latest versions of the `neptune-scale` and `neptune` Python packages installed.
+
+---
+
+## How It Works
+
+- Runs are copied from the legacy project to a project with the same name, key and visibility in the new workspace.
+- The script fetches all runs from the specified legacy project that match the query.
+- For each run, it copies supported metadata and metrics to a new run in the target workspace/project.
+- **Namespace mapping:**
+  - The `monitoring/` namespace in the source run is copied to the `runtime/` namespace in the target run.
+  - All `sys` fields (except a few) are copied to the `legacy_sys` namespace.
+- Unsupported metadata (see Caveats) is skipped.
+- Temporary files are stored in a `.tmp_*` directory for troubleshooting. You can delete this folder after verifying the migration.
+
+---
+
+## Caveats and Limitations
+- Runs can be copied only one project at a time.
+- If a project with the same key as the source project already exists in the new workspace, the script will silently fail.
+- Avoid creating new runs in the source project while the script is running as these might not be copied.
+- Timestamp values appended to each step of series metrics are in the local timezone of the script execution environment. This can lead to variations between the source and target run charts if the X-axis is set to relative time and the source run was created in a different timezone.
+
+### The following metadata are not copied at all
+- Project description and members
+- Project and model metadata
+- Artifacts†
+- FileSet (including source code)†
+- All FileSeries objects†
+  - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries will still not be copied
+- Attributes:
+  - Run state: `sys/state`
+  - Git info: `source_code/git`
+
+† Support for these will be added in future releases.
+
+### The following metadata are not copied in the same format
+- The `monitoring` namespace in the source run is copied to the `runtime` namespace in the target run
+- All `sys` fields except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
+- If the source run does not have a `custom_run_id`, the source run id (`sys/id`) will be used instead as the `run_id` of the target run
+- `sys/running_time` and `sys/monitoring_time` are copied to `legacy_sys/running_time` and `legacy_sys/monitoring_time` respectively as floats in seconds
+- `sys/size` is copied to `legacy_sys/size` as an integer in bytes
+
+---
+
+## Instructions
+
+1. Execute `runs_migrator.py` with the required arguments (see Quick Start).
+1. The script will generate run logs in the working directory. You can modify this location by editing the `setup_logging()` function.
+
+---
+
+## Troubleshooting
+
+- **Project not found:** Ensure the `--legacy-project` is in the correct format and exists in your legacy workspace.
+- **Authentication errors:** Double-check your API tokens and permissions in both the source and target projects.
+- **Partial migration:** Check the log file for errors and rerun the script as needed.
+- **Performance:** Increase `--max-workers` for faster migration, but be mindful of API rate limits.
+
+---
+
+## FAQ
+
+**Q: Can I rerun the script if it fails?**  
+A: Yes, the script is idempotent for already-migrated runs.
+
+**Q: Are artifacts and files copied?**  
+A: Not yet. See the Caveats section for details.
+
+**Q: How do I filter which runs to migrate?**  
+A: Use the `--query` argument with [NQL syntax](https://docs-legacy.neptune.ai/usage/nql/).
+
+---
+
+## Documentation
+
+- [Neptune 2.x Documentation](https://docs-legacy.neptune.ai/)
+- [Neptune 3.x Documentation](https://docs.neptune.ai/)
+- [NQL Query Syntax](https://docs-legacy.neptune.ai/usage/nql/)
+
+---
+
+## Post-Migration Checklist
+
+[ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
+[ ] Add users to the new project and assign them relevant roles  
+[ ] Add project description  
+[ ] Recreate saved views, dashboards, and reports in the new project  
+[ ] Delete the `.tmp_{PROJECT_NAME}_migration_%Y%m%d%H%M%S` folder in the working directory after verifying the migration  
+
+---
+
+## Support and Feedback
+
+We welcome your feedback and contributions to help improve the script. Please submit any issues or feature requests as [GitHub Issues](https://github.com/neptune-ai/scale-examples/issues).
+
+For help, reach out via our support channels:
+- [Support portal](https://support.neptune.ai)
+- [Email](mailto:support@neptune.ai)
+- In-app chat
+
+---
+
+## License
+
+Copyright (c) 2025, Neptune Labs Sp. z o.o.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -63,25 +63,26 @@ python runs_migrator.py \
 - Avoid creating new runs in the source project while the script is running as these might not be copied.
 - Timestamp values appended to each step of series metrics are in the local timezone of the script execution environment. This can lead to variations between the source and target run charts if the X-axis is set to relative time and the source run was created in a different timezone.
 
-### The following metadata are not copied at all
+### The following metadata are not copied in the same format
+- If the source run does not have a `custom_run_id`, the source run id (`sys/id`) will be used instead as the `run_id` of the target run
+- The `monitoring` namespace in the source run is copied to the `runtime` namespace in the target run
+- All `sys` fields except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
+- `sys/running_time` and `sys/monitoring_time` are copied to `legacy_sys/running_time` and `legacy_sys/monitoring_time` respectively as floats in seconds
+- `sys/size` is copied to `legacy_sys/size` as an integer in bytes
+
+### The following metadata are not copied or supported yet
 - Project description and members
 - Project and model metadata
 - Artifacts†
-- FileSet (including source code)†
-- All FileSeries objects†
+- FileSet (including source code)*
+- All FileSeries objects*
   - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries will still not be copied
 - Attributes:
   - Run state: `sys/state`
   - Git info: `source_code/git`
 
-† Support for these will be added in future releases.
+<sup>*</sup> Support for these will be added in upcoming releases.
 
-### The following metadata are not copied in the same format
-- The `monitoring` namespace in the source run is copied to the `runtime` namespace in the target run
-- All `sys` fields except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
-- If the source run does not have a `custom_run_id`, the source run id (`sys/id`) will be used instead as the `run_id` of the target run
-- `sys/running_time` and `sys/monitoring_time` are copied to `legacy_sys/running_time` and `legacy_sys/monitoring_time` respectively as floats in seconds
-- `sys/size` is copied to `legacy_sys/size` as an integer in bytes
 
 ---
 
@@ -90,7 +91,7 @@ python runs_migrator.py \
 [ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
 [ ] Add users to the new project and assign them relevant roles  
 [ ] Add project description  
-[ ] Recreate saved views, dashboards, and reports in the new project  
+[ ] Recreate [saved views](https://docs.neptune.ai/runs_table/#custom-views), [dashboards](https://docs.neptune.ai/custom_dashboard/), and [reports](https://docs.neptune.ai/reports/) in the new project  
 [ ] Delete the `.tmp_{PROJECT_NAME}_migration_%Y%m%d%H%M%S` folder in the working directory after verifying the migration  
 
 ---

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -40,7 +40,7 @@ python runs_migrator.py \
 | `-w`, `--new-workspace` | Yes | Name of the new workspace in Neptune 3.x. |
 | `--new-project` | No | Name of the new project in the format `PROJECT_NAME`. Project will be created if it does not already exist. If not provided, the project name will be the same as the legacy project name. |
 | `-q`, `--query` | No | Query filter for runs to be copied ([NQL syntax](https://docs-legacy.neptune.ai/usage/nql/)). |
-| `--max-workers` | No | Maximum number of parallel workers to use for copying runs. Defaults to using ThreadPoolExecutor's default. |
+| `--max-workers` | No | Maximum number of parallel workers to use for copying runs. Defaults to ThreadPoolExecutor’s default. See [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) for details. |
 
 ---
 
@@ -53,11 +53,11 @@ python runs_migrator.py \
     - All `sys` fields (except a few) are copied to the `legacy_sys` namespace.
   - Files are first downloaded to a temporary directory and then uploaded to the new run.
     - Temporary files are stored in a `.tmp_*` directory for troubleshooting. You can delete this folder after verifying the migration. Ensure that you have sufficient space to store the temporary files.
-  - Unsupported metadata (see Caveats) is skipped.
+  - Unsupported metadata (see Notes and Limitations) is skipped.
 
 ---
 
-## Caveats and Limitations
+## Notes and Limitations
 - Runs can be copied only one project at a time.
 - If a new project name is not provided and a project with the same key as the source project already exists in the new workspace, the script will silently fail.
 - Avoid creating new runs in the source project while the script is running as these might not be copied.

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -75,7 +75,7 @@ python runs_migrator.py \
   - Run state: `sys/state`
   - Git info: `source_code/git`
 
-<sup>*</sup> Support for these will be added in upcoming releases.
+\* Support for these will be added in upcoming releases.
 
 
 ---

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -17,7 +17,6 @@ This script helps you copy runs from Neptune Legacy (2.x) to Neptune (3.x).
 
 ---
 
-## Quick Start
 ## Quickstart
 ```bash
 python runs_migrator.py \
@@ -37,15 +36,12 @@ python runs_migrator.py \
 | `--new-token` | Yes | API token for the new Neptune workspace (3.x). |
 | `--legacy-project` | Yes | Name of the legacy project in the format `WORKSPACE_NAME/PROJECT_NAME`. |
 | `-w`, `--new-workspace` | Yes | Name of the new workspace in Neptune 3.x. |
-| `--new-project` | No | Name of the new project in the format `PROJECT_NAME`. Project will be created if it does not already exist. If not provided, the project name will be the same as the legacy project name. |
 | `--new-project` | No | Name of the new project in the format `PROJECT_NAME`. The project will be created if it doesn't already exist. If not provided, the project name will be the same as the legacy project name. |
 | `--max-workers` | No | Maximum number of parallel workers to use for copying runs. Defaults to ThreadPoolExecutor’s default. See [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) for details. |
 
 ---
 
-## How It Works
 ## How it works
-- The target project is created in the new workspace if it does not already exist.
 - The target project is created in the new workspace if it doesn't already exist.
   - Metrics and parameters are copied from memory
     - The `monitoring/` namespace in the source run is copied to the `runtime/` namespace in the target run.
@@ -56,26 +52,25 @@ python runs_migrator.py \
 
 ---
 
-## Notes and Limitations
-- Runs can be copied only one project at a time.
-- If a new project name is not provided and a project with the same key as the source project already exists in the new workspace, the script will silently fail.
+## Notes and limitations
+- Runs can be copied only from one project at a time.
+- If a new project name isn't provided and a project with the same key as the source project already exists in the new workspace, the script will silently fail.  
 - Avoid creating new runs in the source project while the script is running as these might not be copied.
 - Timestamp values appended to each step of series metrics are in the local timezone of the script execution environment. This can lead to variations between the source and target run charts if the X-axis is set to relative time and the source run was created in a different timezone.
 
-### The following metadata are not copied in the same format
+### Metadata that isn't copied in the same format
 - If the source run does not have a `custom_run_id`, the source run id (`sys/id`) will be used instead as the `run_id` of the target run
 - The `monitoring` namespace in the source run is copied to the `runtime` namespace in the target run
 - All `sys` attributes except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
 - `sys/running_time` and `sys/monitoring_time` are copied to `legacy_sys/running_time` and `legacy_sys/monitoring_time` respectively as floats in seconds
 - `sys/size` is copied to `legacy_sys/size` as an integer in bytes
 
-### The following metadata are not copied or supported yet
+### Data that isn't copied at all or supported yet
 - Project description and members
 - Project and model metadata
 - Artifacts†
 - FileSet (including source code)*
 - All FileSeries objects*
-  - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries will still not be copied
   - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries still won't be copied
   - Run state: `sys/state`
   - Git info: `source_code/git`
@@ -85,13 +80,12 @@ python runs_migrator.py \
 
 ---
 
-## Post-Migration Checklist
 ## Post-migration checklist
 [ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
-[ ] Add users to the new project and assign them relevant roles  
-[ ] Add project description  
-[ ] Recreate [saved views](https://docs.neptune.ai/runs_table/#custom-views), [dashboards](https://docs.neptune.ai/custom_dashboard/), and [reports](https://docs.neptune.ai/reports/) in the new project  
-[ ] Delete the `.tmp_*` folder in the working directory after verifying the migration  
+[ ] Add users to the new project and assign them relevant roles.
+[ ] Add project description.
+[ ] Recreate [saved views](https://docs.neptune.ai/runs_table/#custom-views), [dashboards](https://docs.neptune.ai/custom_dashboard/), and [reports](https://docs.neptune.ai/reports/) in the new project.
+[ ] Delete the `.tmp_*` folder in the working directory after verifying the migration.
 
 ---
 
@@ -117,7 +111,6 @@ A: Use the `--query` argument with [NQL syntax](https://docs-legacy.neptune.ai/u
 
 ---
 
-## Documentation
 ## Documentation
 
 - [Neptune 2.x documentation](https://docs-legacy.neptune.ai/)

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -58,17 +58,17 @@ python runs_migrator.py \
 - Avoid creating new runs in the source project while the script is running as these might not be copied.
 - Timestamp values appended to each step of series metrics are in the local timezone of the script execution environment. This can lead to variations between the source and target run charts if the X-axis is set to relative time and the source run was created in a different timezone.
 
-### Metadata that isn't copied in the same format
-- If the source run does not have a `custom_run_id`, the source run id (`sys/id`) will be used instead as the `run_id` of the target run
+### Data that isn't copied in the same format
+- If the source run doesn't have a `custom_run_id`, the source run ID (`sys/id`) will be used instead as the `run_id` of the target run
 - The `monitoring` namespace in the source run is copied to the `runtime` namespace in the target run
 - All `sys` attributes except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
 - `sys/running_time` and `sys/monitoring_time` are copied to `legacy_sys/running_time` and `legacy_sys/monitoring_time` respectively as floats in seconds
 - `sys/size` is copied to `legacy_sys/size` as an integer in bytes
 
-### Data that isn't copied at all or supported yet
+### Data that isn't copied
 - Project description and members
 - Project and model metadata
-- Artifacts†
+- Artifacts*
 - FileSet (including source code)*
 - All FileSeries objects*
   - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries still won't be copied

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -83,13 +83,6 @@ python runs_migrator.py \
 
 ---
 
-## Instructions
-
-1. Execute `runs_migrator.py` with the required arguments (see Quick Start).
-1. The script will generate run logs in the working directory. You can modify this location by editing the `setup_logging()` function.
-
----
-
 ## Troubleshooting
 
 - **Project not found:** Ensure the `--legacy-project` is in the correct format and exists in your legacy workspace.

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -81,11 +81,11 @@ python runs_migrator.py \
 ---
 
 ## Post-migration checklist
-[ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
-[ ] Add users to the new project and assign them relevant roles.
-[ ] Add project description.
-[ ] Recreate [saved views](https://docs.neptune.ai/runs_table/#custom-views), [dashboards](https://docs.neptune.ai/custom_dashboard/), and [reports](https://docs.neptune.ai/reports/) in the new project.
-[ ] Delete the `.tmp_*` folder in the working directory after verifying the migration.
+- [ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
+- [ ] Add users to the new project and assign them relevant roles.
+- [ ] Add project description.
+- [ ] Recreate [saved views](https://docs.neptune.ai/runs_table/#custom-views), [dashboards](https://docs.neptune.ai/custom_dashboard/), and [reports](https://docs.neptune.ai/reports/) in the new project.
+- [ ] Delete the `.tmp_*` folder in the working directory after verifying the migration.
 
 ---
 

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -6,14 +6,20 @@ This script helps you copy runs from Neptune Legacy (2.x) to Neptune (3.x).
 ## Changelog
 - 2025-05-19 - Initial release
 
+---
+
+## Prerequisites
+- A Neptune 2.x workspace with runs to migrate.
+- A Neptune 3.x workspace with write access to migrate the runs to.
+- Latest versions of the `neptune-scale` and `neptune` Python packages installed:
+  ```bash
+  pip install -U neptune-scale neptune
+  ```
+
+---
+
 ## Quick Start
 
-Install the required packages:
-```bash
-pip install -U neptune-scale neptune
-```
-
-Run the migration script:
 ```bash
 python runs_migrator.py \
   --legacy-token <NEPTUNE_2.X_API_TOKEN> \
@@ -26,23 +32,15 @@ python runs_migrator.py \
 
 ## Arguments
 
-- `--legacy-token` (required): API token for the legacy Neptune workspace (2.x).
-- `--new-token` (required): API token for the new Neptune workspace (3.x).
-- `--legacy-project` (required): Name of the legacy project in the format `WORKSPACE_NAME/PROJECT_NAME`.
-- `--new-workspace` (required): Name of the new workspace in Neptune 3.x.
-- `--new-project` (optional): Name of the new project in the format `PROJECT_NAME`. Project will be created if it does not already exist. If not provided, the project name will be the same as the legacy project name.
-- `--query` (optional): Query filter for runs to be copied ([NQL syntax](https://docs-legacy.neptune.ai/usage/nql/)).
-- `--max-workers` (optional): Maximum number of parallel workers to use for copying runs. Defaults to using ThreadPoolExecutor's default.
-
----
-
-## Prerequisites
-- A Neptune 2.x workspace with runs to migrate.
-- A Neptune 3.x workspace with write access to migrate the runs to.
-- Latest versions of the `neptune-scale` and `neptune` Python packages installed:
-  ```bash
-  pip install -U neptune-scale neptune
-  ```
+| Argument | Required | Description |
+| --- | --- | --- |
+| `--legacy-token` | Yes | API token for the legacy Neptune workspace (2.x). |
+| `--new-token` | Yes | API token for the new Neptune workspace (3.x). |
+| `--legacy-project` | Yes | Name of the legacy project in the format `WORKSPACE_NAME/PROJECT_NAME`. |
+| `-w`, `--new-workspace` | Yes | Name of the new workspace in Neptune 3.x. |
+| `--new-project` | No | Name of the new project in the format `PROJECT_NAME`. Project will be created if it does not already exist. If not provided, the project name will be the same as the legacy project name. |
+| `-q`, `--query` | No | Query filter for runs to be copied ([NQL syntax](https://docs-legacy.neptune.ai/usage/nql/)). |
+| `--max-workers` | No | Maximum number of parallel workers to use for copying runs. Defaults to using ThreadPoolExecutor's default. |
 
 ---
 
@@ -87,6 +85,16 @@ python runs_migrator.py \
 
 ---
 
+## Post-Migration Checklist
+
+[ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
+[ ] Add users to the new project and assign them relevant roles  
+[ ] Add project description  
+[ ] Recreate saved views, dashboards, and reports in the new project  
+[ ] Delete the `.tmp_{PROJECT_NAME}_migration_%Y%m%d%H%M%S` folder in the working directory after verifying the migration  
+
+---
+
 ## Troubleshooting
 
 - **Project not found:** Ensure the `--legacy-project` is in the correct format and exists in your legacy workspace.
@@ -114,16 +122,6 @@ A: Use the `--query` argument with [NQL syntax](https://docs-legacy.neptune.ai/u
 - [Neptune 2.x Documentation](https://docs-legacy.neptune.ai/)
 - [Neptune 3.x Documentation](https://docs.neptune.ai/)
 - [NQL Query Syntax](https://docs-legacy.neptune.ai/usage/nql/)
-
----
-
-## Post-Migration Checklist
-
-[ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
-[ ] Add users to the new project and assign them relevant roles  
-[ ] Add project description  
-[ ] Recreate saved views, dashboards, and reports in the new project  
-[ ] Delete the `.tmp_{PROJECT_NAME}_migration_%Y%m%d%H%M%S` folder in the working directory after verifying the migration  
 
 ---
 

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -92,7 +92,7 @@ python runs_migrator.py \
 [ ] Add users to the new project and assign them relevant roles  
 [ ] Add project description  
 [ ] Recreate [saved views](https://docs.neptune.ai/runs_table/#custom-views), [dashboards](https://docs.neptune.ai/custom_dashboard/), and [reports](https://docs.neptune.ai/reports/) in the new project  
-[ ] Delete the `.tmp_{PROJECT_NAME}_migration_%Y%m%d%H%M%S` folder in the working directory after verifying the migration  
+[ ] Delete the `.tmp_*` folder in the working directory after verifying the migration  
 
 ---
 

--- a/utils/migration_tools/from_legacy_neptune/README.md
+++ b/utils/migration_tools/from_legacy_neptune/README.md
@@ -9,8 +9,7 @@ This script helps you copy runs from Neptune Legacy (2.x) to Neptune (3.x).
 ---
 
 ## Prerequisites
-- A Neptune 2.x workspace with runs to migrate.
-- A Neptune 3.x workspace with write access to migrate the runs to.
+- A workspace in Neptune 3.x, and an API token that has access to the workspace.
 - Latest versions of the `neptune-scale` and `neptune` Python packages installed:
   ```bash
   pip install -U neptune-scale neptune
@@ -19,7 +18,7 @@ This script helps you copy runs from Neptune Legacy (2.x) to Neptune (3.x).
 ---
 
 ## Quick Start
-
+## Quickstart
 ```bash
 python runs_migrator.py \
   --legacy-token <NEPTUNE_2.X_API_TOKEN> \
@@ -39,18 +38,18 @@ python runs_migrator.py \
 | `--legacy-project` | Yes | Name of the legacy project in the format `WORKSPACE_NAME/PROJECT_NAME`. |
 | `-w`, `--new-workspace` | Yes | Name of the new workspace in Neptune 3.x. |
 | `--new-project` | No | Name of the new project in the format `PROJECT_NAME`. Project will be created if it does not already exist. If not provided, the project name will be the same as the legacy project name. |
-| `-q`, `--query` | No | Query filter for runs to be copied ([NQL syntax](https://docs-legacy.neptune.ai/usage/nql/)). |
+| `--new-project` | No | Name of the new project in the format `PROJECT_NAME`. The project will be created if it doesn't already exist. If not provided, the project name will be the same as the legacy project name. |
 | `--max-workers` | No | Maximum number of parallel workers to use for copying runs. Defaults to ThreadPoolExecutor’s default. See [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor) for details. |
 
 ---
 
 ## How It Works
-
+## How it works
 - The target project is created in the new workspace if it does not already exist.
-- All runs that match the query are copied from the legacy project to the new project.
+- The target project is created in the new workspace if it doesn't already exist.
   - Metrics and parameters are copied from memory
     - The `monitoring/` namespace in the source run is copied to the `runtime/` namespace in the target run.
-    - All `sys` fields (except a few) are copied to the `legacy_sys` namespace.
+    - Most `sys` attributes are copied to the `legacy_sys` namespace. For details, see [Notes and Limitations](#notes-and-limitations).
   - Files are first downloaded to a temporary directory and then uploaded to the new run.
     - Temporary files are stored in a `.tmp_*` directory for troubleshooting. You can delete this folder after verifying the migration. Ensure that you have sufficient space to store the temporary files.
   - Unsupported metadata (see Notes and Limitations) is skipped.
@@ -66,7 +65,7 @@ python runs_migrator.py \
 ### The following metadata are not copied in the same format
 - If the source run does not have a `custom_run_id`, the source run id (`sys/id`) will be used instead as the `run_id` of the target run
 - The `monitoring` namespace in the source run is copied to the `runtime` namespace in the target run
-- All `sys` fields except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
+- All `sys` attributes except `state`, `description`, `name`, `custom_run_id`, `tags`, and `group_tags` are copied to the `legacy_sys` namespace
 - `sys/running_time` and `sys/monitoring_time` are copied to `legacy_sys/running_time` and `legacy_sys/monitoring_time` respectively as floats in seconds
 - `sys/size` is copied to `legacy_sys/size` as an integer in bytes
 
@@ -77,7 +76,7 @@ python runs_migrator.py \
 - FileSet (including source code)*
 - All FileSeries objects*
   - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries will still not be copied
-- Attributes:
+  - Once FileSeries are supported in Neptune 3.x, the custom steps and descriptions of files in FileSeries still won't be copied
   - Run state: `sys/state`
   - Git info: `source_code/git`
 
@@ -87,7 +86,7 @@ python runs_migrator.py \
 ---
 
 ## Post-Migration Checklist
-
+## Post-migration checklist
 [ ] Review the logs for any errors. They also contain the URLs of both the source and target runs.  
 [ ] Add users to the new project and assign them relevant roles  
 [ ] Add project description  
@@ -108,10 +107,10 @@ python runs_migrator.py \
 ## FAQ
 
 **Q: Can I rerun the script if it fails?**  
-A: Yes, the script is idempotent for already-migrated runs.
+A: Yes, runs already migrated will not be duplicated.
 
 **Q: Are artifacts and files copied?**  
-A: Not yet. See the Caveats section for details.
+A: Not yet. See the [Notes and Limitations](#notes-and-limitations) section for details.
 
 **Q: How do I filter which runs to migrate?**  
 A: Use the `--query` argument with [NQL syntax](https://docs-legacy.neptune.ai/usage/nql/).
@@ -119,15 +118,15 @@ A: Use the `--query` argument with [NQL syntax](https://docs-legacy.neptune.ai/u
 ---
 
 ## Documentation
+## Documentation
 
-- [Neptune 2.x Documentation](https://docs-legacy.neptune.ai/)
-- [Neptune 3.x Documentation](https://docs.neptune.ai/)
-- [NQL Query Syntax](https://docs-legacy.neptune.ai/usage/nql/)
+- [Neptune 2.x documentation](https://docs-legacy.neptune.ai/)
+- [Neptune 3.x documentation](https://docs.neptune.ai/)
+- [NQL query syntax](https://docs-legacy.neptune.ai/usage/nql/)
 
 ---
 
-## Support and Feedback
-
+## Support and feedback
 We welcome your feedback and contributions to help improve the script. Please submit any issues or feature requests as [GitHub Issues](https://github.com/neptune-ai/scale-examples/issues).
 
 For help, reach out via our support channels:

--- a/utils/migration_tools/from_legacy_neptune/runs_migrator.py
+++ b/utils/migration_tools/from_legacy_neptune/runs_migrator.py
@@ -408,7 +408,7 @@ def fetch_args() -> argparse.Namespace:
         "--new-project",
         type=str,
         default=None,
-        help="New project name (without workspace name). Project will be created if it does not already exist. If not provided, the project name will be the same as the legacy project name.",
+        help="The project will be created if it doesn't already exist. If not provided, the project name will be the same as the legacy project name.",
     )
     parser.add_argument(
         "-q",

--- a/utils/migration_tools/from_legacy_neptune/runs_migrator.py
+++ b/utils/migration_tools/from_legacy_neptune/runs_migrator.py
@@ -1,0 +1,462 @@
+#
+# Copyright (c) 2025, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Instructions on how to use this script can be found at
+# https://github.com/neptune-ai/scale-examples/blob/main/utils/migration_tools/from_legacy_neptune/README.md
+
+# TODO: Check the following cases:
+# - 1 run copied using 1 worker
+# - 1 run copied using multiple workers
+# - Multiple runs copied using 1 worker
+# - Multiple runs copied using multiple workers
+
+import argparse
+import base64
+import contextlib
+import functools
+import json
+import logging
+import os
+import sys
+import threading
+import traceback
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from datetime import datetime
+from glob import glob
+from typing import Optional
+
+import neptune.metadata_containers
+from neptune import management
+from neptune.exceptions import MetadataInconsistency, MissingFieldException
+from neptune.types import File
+from neptune_scale import Run
+from neptune_scale.exceptions import (
+    NeptuneSeriesStepNonIncreasing,
+    NeptuneSeriesTimestampDecreasing,
+)
+from neptune_scale.projects import create_project
+from tqdm.auto import tqdm
+
+logging.getLogger("httpx").setLevel(logging.ERROR)
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+logging.getLogger("neptune").setLevel(logging.ERROR)
+logging.getLogger("neptune_scale").setLevel(logging.ERROR)
+
+READ_ONLY_NAMESPACES = {
+    "sys/id",
+    "sys/modification_time",
+    "sys/monitoring_time",
+    "sys/owner",
+    "sys/ping_time",
+    "sys/running_time",
+    "sys/size",
+    "sys/trashed",
+}
+
+UNFETCHABLE_NAMESPACES = {
+    "sys/state",
+    "source_code/git",
+}
+
+
+def map_namespace(namespace: str) -> str:
+    if namespace in READ_ONLY_NAMESPACES:
+        return namespace.replace("sys", "legacy_sys")
+    if namespace.startswith("monitoring/"):
+        return "runtime/" + namespace[len("monitoring/") :]
+    return namespace
+
+
+@contextmanager
+def threadsafe_change_directory(new_dir):
+    lock = threading.Lock()
+    old_dir = os.getcwd()
+    try:
+        with lock:
+            os.chdir(new_dir)
+        yield
+    finally:
+        with lock:
+            os.chdir(old_dir)
+
+
+def log_error(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            with contextlib.suppress(MissingFieldException):
+                return func(*args, **kwargs)
+        except Exception as e:
+            logging.error(f"Failed to copy {args[-1]}/{args[1]} due to exception:\n{e}")
+
+    return wrapper
+
+
+def flatten_namespaces(
+    dictionary: dict, prefix: Optional[list] = None, result: Optional[list] = None
+) -> list:
+    if prefix is None:
+        prefix = []
+    if result is None:
+        result = []
+
+    for k, v in dictionary.items():
+        if isinstance(v, dict):
+            flatten_namespaces(v, prefix + [k], result)
+        elif prefix_str := "/".join(prefix):
+            result.append(f"{prefix_str}/{k}")
+        else:
+            result.append(k)
+    return result
+
+
+def setup_logging(project: str) -> tuple[logging.Logger, str]:
+    now = datetime.now()
+    log_filename = now.strftime(f"{project.replace('/', '_')}_migration_%Y%m%d%H%M%S.log")
+
+    logging.basicConfig(
+        filename=log_filename,
+        filemode="a",
+        format="%(asctime)s\t%(levelname)s\t%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.INFO,
+        force=True,
+    )
+
+    logger = logging.getLogger(__name__)
+
+    print(f"Logs available at {os.path.abspath(log_filename)}\n")
+
+    return logger, log_filename
+
+
+def exc_handler(logger: logging.Logger, exctype, value, tb):
+    logger.exception("".join(traceback.format_exception(exctype, value, tb)))
+
+
+def create_temporary_directory(log_filename: str) -> str:
+    tmpdirname = os.path.abspath(
+        os.path.join(os.getcwd(), f".tmp_{log_filename.replace('.log', '')}")
+    )
+    os.mkdir(tmpdirname)
+
+    return tmpdirname
+
+
+def validate_source_project(legacy_token: str, project: str):
+    if project not in management.get_project_list(api_token=legacy_token):
+        print(
+            f"ERROR: Source project {project} does not exist. Please check project name",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def fetch_project_metadata(legacy_token: str, project: str) -> dict:
+    with neptune.init_project(
+        project=project,
+        api_token=legacy_token,
+        mode="read-only",
+    ) as legacy_project:
+        legacy_project_details = {
+            "key": legacy_project["sys/id"].fetch(),
+            "visibility": legacy_project["sys/visibility"].fetch(),
+            "url": legacy_project.get_url(),
+        }
+        if legacy_project_details["visibility"] == "public":
+            legacy_project_details["visibility"] = "pub"
+        elif legacy_project_details["visibility"] == "private":
+            legacy_project_details["visibility"] = "priv"
+
+        return legacy_project_details
+
+
+def fetch_source_runs(legacy_token: str, project: str, query: Optional[str] = None) -> list[str]:
+    with neptune.init_project(
+        project=project,
+        api_token=legacy_token,
+        mode="read-only",
+    ) as source_project:
+        return source_project.fetch_runs_table(columns=[], query=query).to_pandas()["sys/id"].values
+
+
+@log_error
+def copy_artifacts(source_run, namespace, run, id):
+    # TODO: Not implemented in the new Neptune API
+    return
+    for artifact_location in [
+        artifact.metadata["location"] for artifact in source_run[namespace].fetch_files_list()
+    ]:
+        run[map_namespace(namespace)].track_files(artifact_location)
+
+
+@log_error
+def copy_stringset(source_run, namespace, run, id):
+    with contextlib.suppress(MissingFieldException, MetadataInconsistency):
+        run.log_configs({map_namespace(namespace): source_run[namespace].fetch()})
+
+
+@log_error
+def copy_float_series(source_run, namespace, run, id):
+    for row in source_run[namespace].fetch_values(progress_bar=False).itertuples():
+        run.log_metrics(
+            {map_namespace(namespace): row.value},
+            step=row.step,
+            timestamp=row.timestamp,
+        )
+
+
+@log_error
+def copy_string_series(source_run, namespace, run, id):
+    for row in source_run[namespace].fetch_values(progress_bar=False).itertuples():
+        run.log_string_series(
+            {map_namespace(namespace): row.value},
+            step=row.step,
+            timestamp=row.timestamp,
+        )
+
+
+@log_error
+def copy_file(source_run, namespace, run, localpath, id):
+    ext = source_run[namespace].fetch_extension()
+
+    path = os.sep.join(namespace.split("/")[:-1])
+    _download_path = os.path.join(localpath, path)
+    os.makedirs(_download_path, exist_ok=True)
+    source_run[namespace].download(_download_path, progress_bar=False)
+    run.assign_files({map_namespace(namespace): f"{os.path.join(localpath, namespace)}.{ext}"})
+
+
+@log_error
+def copy_fileset(source_run, namespace, run, localpath, id):
+    # TODO: Not implemented in the new Neptune API
+    return
+    _download_path = os.path.join(localpath, namespace)
+    os.makedirs(_download_path, exist_ok=True)
+    source_run[namespace].download(_download_path, progress_bar=False)
+
+    _zip_path = os.path.join(_download_path, f"{namespace.split('/')[-1]}.zip")
+    with zipfile.ZipFile(_zip_path) as zip_ref:
+        zip_ref.extractall(_download_path)
+    os.remove(_zip_path)
+
+    with threadsafe_change_directory(_download_path):
+        run[map_namespace(namespace)].upload_files(
+            "*",
+            wait=True,
+        )
+
+
+@log_error
+def copy_fileseries(source_run, namespace, run, localpath, id):
+    # TODO: Not implemented in the new Neptune API
+    return
+    _download_path = os.path.join(localpath, namespace)
+    source_run[namespace].download(_download_path, progress_bar=False)
+    for step, file in enumerate(glob(f"{_download_path}{os.sep}*")):
+        run.log_files(
+            {map_namespace(namespace): File(file)},
+            step=step,
+        )
+
+
+@log_error
+def copy_atom(source_run, namespace, run, id):
+    run.log_configs({map_namespace(namespace): source_run[namespace].fetch()})
+
+
+def copy_metadata(
+    source_run: neptune.Run,
+    object_id: str,
+    target_run: neptune.Run,
+    tmpdirname: str,
+) -> None:
+    namespaces = flatten_namespaces(source_run.get_structure())
+
+    _local_path = os.path.join(tmpdirname, object_id)
+
+    for namespace in namespaces:
+        if namespace in UNFETCHABLE_NAMESPACES:
+            continue
+
+        mapped_namespace = map_namespace(namespace)
+
+        if namespace in READ_ONLY_NAMESPACES:
+            # Create legacy_sys namespaces for read-only sys namespaces
+            target_run.log_configs({mapped_namespace: source_run[namespace].fetch()})
+
+        elif str(source_run[namespace]).startswith("<Artifact"):
+            copy_artifacts(source_run, namespace, target_run, object_id)
+
+        elif str(source_run[namespace]).startswith("<StringSet"):
+            copy_stringset(source_run, namespace, target_run, object_id)
+
+        elif str(source_run[namespace]).startswith("<FloatSeries"):
+            copy_float_series(source_run, namespace, target_run, object_id)
+
+        elif str(source_run[namespace]).startswith("<StringSeries"):
+            copy_string_series(source_run, namespace, target_run, object_id)
+
+        elif str(source_run[namespace]).startswith("<FileSet"):
+            copy_fileset(source_run, namespace, target_run, _local_path, object_id)
+
+        elif str(source_run[namespace]).startswith("<FileSeries"):
+            copy_fileseries(source_run, namespace, target_run, _local_path, object_id)
+
+        elif str(source_run[namespace]).startswith("<File"):
+            copy_file(source_run, namespace, target_run, _local_path, object_id)
+
+        else:
+            copy_atom(source_run, namespace, target_run, object_id)
+
+    target_run.wait_for_processing(verbose=False)
+
+
+def init_target_run(
+    source_run: neptune.Run, args: argparse.Namespace, logger: logging.Logger
+) -> Run:
+    def _error_callback(exc: BaseException, ts: Optional[float]) -> None:
+        if isinstance(exc, (NeptuneSeriesStepNonIncreasing, NeptuneSeriesTimestampDecreasing)):
+            logger.warning(f"Encountered {exc} error while copying {source_run['sys/id'].fetch()}")
+        else:
+            target_run.close()
+
+    custom_run_id = source_run["sys/id"].fetch()
+    with contextlib.suppress(MissingFieldException):
+        custom_run_id = source_run["sys/custom_run_id"].fetch()
+
+    target_run = Run(
+        run_id=custom_run_id,
+        project=f"{args.new_workspace}/{args.legacy_project.split('/')[1]}",
+        api_token=args.new_token,
+        creation_time=source_run["sys/creation_time"].fetch(),
+        enable_console_log_capture=False,
+        on_error_callback=_error_callback,
+    )
+    return target_run
+
+
+def copy_run(source_run_id: str, args: argparse.Namespace, logger: logging.Logger, tmpdirname: str):
+    with neptune.init_run(
+        project=args.legacy_project,
+        api_token=args.legacy_token,
+        with_id=source_run_id,
+        mode="read-only",
+    ) as source_run:
+        with init_target_run(source_run, args, logger) as target_run:
+            copy_metadata(source_run, source_run_id, target_run, tmpdirname)
+            logger.info(f"Copied {source_run.get_url()} to {target_run.get_run_url()}")
+
+
+def fetch_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Migrate Neptune runs from a legacy workspace to a new workspace."
+    )
+    parser.add_argument(
+        "--legacy-token", type=str, required=True, help="API token for the legacy workspace"
+    )
+    parser.add_argument(
+        "--new-token", type=str, required=True, help="API token for the new workspace"
+    )
+    parser.add_argument(
+        "-w",
+        "--new-workspace",
+        type=str,
+        required=True,
+        help="New workspace name",
+    )
+    parser.add_argument(
+        "-p",
+        "--legacy-project",
+        type=str,
+        required=True,
+        help="Legacy project name (in WORKSPACE_NAME/PROJECT_NAME format)",
+    )
+    parser.add_argument(
+        "-q",
+        "--query",
+        type=str,
+        default=None,
+        help="Query filter for runs to be copied (Syntax: https://docs-legacy.neptune.ai/usage/nql/)",
+    )
+
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Maximum number of parallel workers to use (default: ThreadPoolExecutor's default)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = fetch_args()
+
+    validate_source_project(args.legacy_token, args.legacy_project)
+
+    logger, log_filename = setup_logging(args.legacy_project)
+    sys.excepthook = functools.partial(exc_handler, logger)
+
+    legacy_project_details = fetch_project_metadata(args.legacy_token, args.legacy_project)
+    create_project(
+        api_token=args.new_token,
+        workspace=args.new_workspace,
+        name=args.legacy_project.split("/")[1],
+        key=legacy_project_details["key"],
+        visibility=legacy_project_details["visibility"],
+    )
+
+    logger.info(f"Source project URL: {legacy_project_details['url']}runs")
+    scale_instance_url = json.loads(base64.urlsafe_b64decode(args.new_token))["api_url"]
+    logger.info(
+        f"Target project URL: {scale_instance_url}/o/{args.new_workspace}/org/{args.legacy_project.split('/')[1]}/runs"
+    )
+
+    source_run_ids = fetch_source_runs(args.legacy_token, args.legacy_project, args.query)
+    logger.info(f"Found {len(source_run_ids)} runs to copy")
+
+    tmpdirname = create_temporary_directory(log_filename)
+    logger.info(f"Temporary directory created at {tmpdirname}")
+
+    try:
+        with ThreadPoolExecutor(max_workers=args.max_workers) as executor:
+            future_to_run = {
+                executor.submit(copy_run, source_run_id, args, logger, tmpdirname): source_run_id
+                for source_run_id in source_run_ids
+            }
+
+            for future in tqdm(as_completed(future_to_run), total=len(source_run_ids)):
+                source_run_id = future_to_run[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.exception(f"Failed to copy {source_run_id} due to exception:\n{e}")
+
+            logger.info("Export complete!")
+            print("\nDone!")
+    except Exception as e:
+        logger.exception(f"Error during export: {e}")
+        print("\nError!")
+        raise e
+
+    finally:
+        logging.shutdown()
+        print(f"Check logs at {os.path.abspath(log_filename)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Include a summary of the changes and the related issue.

__Related to:__ https://linear.app/neptuneai/issue/CUS-7/legacy-to-scale-migration-script-v0

__Any expected test failures?__


---

Add a `[X]` to relevant checklist items

## ❔ This change

- [X] adds a new feature
- [ ] fixes breaking code
- [ ] is cosmetic (refactoring/reformatting)

---

## ✔️ Pre-merge checklist

- [X] Refactored code ([sourcery](https://sourcery.ai/))
- [X] Tested code locally
- [X] Precommit installed and run before pushing changes
- [ ] Added code to GitHub tests ([notebooks](workflows/test-notebooks.yml), [scripts](workflows/test-scripts.yml))
- [X] Updated GitHub [README](../README.md)
- [ ] Updated the projects overview page on Notion

---

## 🧪 Test Configuration

- OS: Windows and Linux
- Python version: 3.11.9
- Neptune version: 0.12.1
- Affected libraries with version:

## Summary by Sourcery

Add a new migration script and documentation to automate copying runs from legacy Neptune 2.x projects into Neptune 3.x, with namespace remapping, parallel execution, and detailed usage guidance

New Features:
- Add a CLI migration tool (`runs_migrator.py`) to copy runs from Neptune Legacy (2.x) to Neptune (3.x) projects

Enhancements:
- Implement mappings of legacy `sys/` and `monitoring/` namespaces to new `legacy_sys/` and `runtime/` formats and apply type-specific copy routines with error logging

Documentation:
- Add a comprehensive README for the migration tool with usage examples, argument reference, limitations, and troubleshooting
- Update the root README to link to the new migration script’s documentation and code